### PR TITLE
improve query for transport nodes

### DIFF
--- a/roles/nsxt/nsxt-transport-nodes/tasks/main.yml
+++ b/roles/nsxt/nsxt-transport-nodes/tasks/main.yml
@@ -44,9 +44,9 @@
   register: host_transport_node_facts
   retries: 120
   delay: 10
-  until: 
-  - host_transport_node_facts.results
-  - host_transport_node_facts | community.general.json_query(host_node_query)
+  until:
+    - host_transport_node_facts.results
+    - host_transport_node_facts | community.general.json_query(host_node_query)
   vars:
     host_node_query: "results[?node_deployment_info.resource_type=='HostNode'].node_deployment_info.managed_by_server"
 

--- a/roles/nsxt/nsxt-transport-nodes/tasks/main.yml
+++ b/roles/nsxt/nsxt-transport-nodes/tasks/main.yml
@@ -44,7 +44,11 @@
   register: host_transport_node_facts
   retries: 120
   delay: 10
-  until: host_transport_node_facts.results and host_transport_node_facts.results[0].node_deployment_info.managed_by_server
+  until: 
+  - host_transport_node_facts.results
+  - host_transport_node_facts | community.general.json_query(host_node_query)
+  vars:
+    host_node_query: "results[?node_deployment_info.resource_type=='HostNode'].node_deployment_info.managed_by_server"
 
 - ansible.builtin.debug: msg="Creating edge nodes {{ nsxt.edge_nodes }}"
 


### PR DESCRIPTION
to only query for host nodes and not edge nodes.

If both host nodes and edge nodes exist, the full json looks like this:

```json
{
  "changed": false,
  "failed": false,
  "result_count": 2,
  "results": [
    {
      "_create_time": 1727690509426,
      "_create_user": "admin",
      "_last_modified_time": 1727690876190,
      "_last_modified_user": "admin",
      "_protection": "NOT_PROTECTED",
      "_revision": 1,
      "_system_owned": false,
      "display_name": "edge-node-1",
      "failure_domain_id": "4fc1e3b0-1cd4-4339-86c8-f76baddbaafb",
      "host_switch_spec": {
        "host_switches": [
          {
            "cpu_config": [],
            "host_switch_id": "12121a2d-d01c-45df-94aa-d2d2b3e68a39",
            "host_switch_mode": "STANDARD",
            "host_switch_name": "defaultHostSwitch",
            "host_switch_profile_ids": [
              {
                "key": "UplinkHostSwitchProfile",
                "value": "3d10321a-c50e-472b-bf30-1af4a27ce3d9"
              }
            ],
            "host_switch_type": "NVDS",
            "ip_assignment_spec": {
              "ip_pool_id": "9da01264-9497-4fdb-a6c1-9da6f26e7489",
              "resource_type": "StaticIpPoolSpec"
            },
            "is_migrate_pnics": false,
            "not_ready": false,
            "pnics": [
              {
                "device_name": "fp-eth2",
                "uplink_name": "uplink-1"
              }
            ],
            "pnics_uninstall_migration": [],
            "transport_zone_endpoints": [
              {
                "transport_zone_id": "c438e640-c193-4130-ae2e-26858d6eb64d",
                "transport_zone_profile_ids": [
                  {
                    "profile_id": "52035bb3-ab02-4a08-9884-18631312e50a",
                    "resource_type": "BfdHealthMonitoringProfile"
                  }
                ]
              }
            ],
            "vmk_uninstall_migration": []
          },
          {
            "cpu_config": [],
            "host_switch_id": "e132aa62-dacc-4411-bf00-93921c386ce1",
            "host_switch_mode": "STANDARD",
            "host_switch_name": "sw_vlan",
            "host_switch_profile_ids": [
              {
                "key": "UplinkHostSwitchProfile",
                "value": "df47d3bd-e222-4635-b3c4-1bba3e0346f9"
              }
            ],
            "host_switch_type": "NVDS",
            "ip_assignment_spec": {
              "resource_type": "AssignedByDhcp"
            },
            "is_migrate_pnics": false,
            "not_ready": false,
            "pnics": [
              {
                "device_name": "fp-eth0",
                "uplink_name": "uplink-1"
              }
            ],
            "pnics_uninstall_migration": [],
            "transport_zone_endpoints": [
              {
                "transport_zone_id": "addf2f92-ea59-4c20-82fb-1328bc27abf3",
                "transport_zone_profile_ids": [
                  {
                    "profile_id": "52035bb3-ab02-4a08-9884-18631312e50a",
                    "resource_type": "BfdHealthMonitoringProfile"
                  }
                ]
              }
            ],
            "vmk_uninstall_migration": []
          }
        ],
        "resource_type": "StandardHostSwitchSpec"
      },
      "id": "24fe0d22-8eb7-4dc2-b9cb-dc3909d8f96e",
      "is_overridden": false,
      "maintenance_mode": "DISABLED",
      "node_deployment_info": {
        "_revision": 1,
        "deployment_config": {
          "form_factor": "MEDIUM",
          "node_user_settings": {
            "audit_username": "audit",
            "cli_username": "admin"
          },
          "vm_deployment_config": {
            "compute_id": "domain-c8",
            "data_network_ids": [
              "network-15",
              "dvportgroup-1002",
              "dvportgroup-1002"
            ],
            "default_gateway_addresses": [
              "172.20.16.1"
            ],
            "ipv4_assignment_disabled": false,
            "ipv4_assignment_enabled": true,
            "management_network_id": "network-15",
            "management_port_subnets": [
              {
                "ip_addresses": [
                  "172.20.16.12"
                ],
                "prefix_length": 22
              }
            ],
            "placement_type": "VsphereDeploymentConfig",
            "reservation_info": {
              "cpu_reservation": {
                "reservation_in_shares": "HIGH_PRIORITY"
              },
              "memory_reservation": {
                "reservation_percentage": 100
              }
            },
            "resource_allocation": {
              "cpu_count": 4,
              "memory_allocation_in_mb": 8192
            },
            "storage_id": "datastore-16",
            "vc_id": "05c516c3-df3f-4885-baf6-9d63c03d6e07"
          }
        },
        "deployment_type": "VIRTUAL_MACHINE",
        "display_name": "edge-node-1",
        "external_id": "24fe0d22-8eb7-4dc2-b9cb-dc3909d8f96e",
        "id": "24fe0d22-8eb7-4dc2-b9cb-dc3909d8f96e",
        "ip_addresses": [
          "172.20.16.12"
        ],
        "node_settings": {
          "allow_ssh_root_login": true,
          "enable_ssh": true,
          "enable_upt_mode": false,
          "hostname": "172-20-16-12.nip.io",
          "ntp_servers": [
            "192.168.178.1"
          ]
        },
        "resource_type": "EdgeNode"
      },
      "node_id": "24fe0d22-8eb7-4dc2-b9cb-dc3909d8f96e",
      "resource_type": "TransportNode"
    },
    {
      "_create_time": 1727690216554,
      "_create_user": "system",
      "_last_modified_time": 1727692700144,
      "_last_modified_user": "admin",
      "_protection": "NOT_PROTECTED",
      "_revision": 2,
      "_system_owned": false,
      "description": "",
      "display_name": "172.20.16.14",
      "host_switch_spec": {
        "host_switches": [
          {
            "cpu_config": [],
            "host_switch_id": "50 1b dc d6 75 2a 1b c9-56 b9 74 d3 5b 65 0a 37",
            "host_switch_mode": "STANDARD",
            "host_switch_name": "nsxt-vds",
            "host_switch_profile_ids": [
              {
                "key": "UplinkHostSwitchProfile",
                "value": "b57c54d4-1c0d-4274-a6f8-12cbb31a7ffb"
              },
              {
                "key": "VtepHAHostSwitchProfile",
                "value": "0de8282e-7385-4e8e-a905-0c11960db728"
              }
            ],
            "host_switch_type": "VDS",
            "ip_assignment_spec": {
              "ip_pool_id": "9da01264-9497-4fdb-a6c1-9da6f26e7489",
              "resource_type": "StaticIpPoolSpec"
            },
            "is_migrate_pnics": false,
            "not_ready": false,
            "portgroup_transport_zone_id": "223346a0-2091-3c45-aa19-53913786ba19",
            "transport_zone_endpoints": [
              {
                "transport_zone_id": "c438e640-c193-4130-ae2e-26858d6eb64d",
                "transport_zone_profile_ids": [
                  {
                    "profile_id": "52035bb3-ab02-4a08-9884-18631312e50a",
                    "resource_type": "BfdHealthMonitoringProfile"
                  }
                ]
              },
              {
                "transport_zone_id": "addf2f92-ea59-4c20-82fb-1328bc27abf3",
                "transport_zone_profile_ids": [
                  {
                    "profile_id": "52035bb3-ab02-4a08-9884-18631312e50a",
                    "resource_type": "BfdHealthMonitoringProfile"
                  }
                ]
              }
            ],
            "uplinks": [
              {
                "uplink_name": "uplink-1",
                "vds_uplink_name": "Uplink 1"
              }
            ]
          }
        ],
        "resource_type": "StandardHostSwitchSpec"
      },
      "id": "4d758ec6-92ed-47a3-a9d6-eefd6242a3ea",
      "is_overridden": false,
      "maintenance_mode": "DISABLED",
      "node_deployment_info": {
        "compute_collection_id": "05c516c3-df3f-4885-baf6-9d63c03d6e07:domain-c8",
        "discovered_ip_addresses": [
          "172.20.20.1",
          "fe80::250:56ff:fe6c:3b29",
          "172.20.16.14",
          "fe80::250:acff:fe14:100e",
          "169.254.1.1",
          "fe80::250:56ff:fe64:eac"
        ],
        "discovered_node_id": "05c516c3-df3f-4885-baf6-9d63c03d6e07:host-11",
        "external_id": "4d758ec6-92ed-47a3-a9d6-eefd6242a3ea",
        "fqdn": "nsxt2-esx1",
        "id": "4d758ec6-92ed-47a3-a9d6-eefd6242a3ea",
        "ip_addresses": [
          "172.20.16.14"
        ],
        "managed_by_server": "172.20.16.10",
        "os_type": "ESXI",
        "os_version": "7.0.3",
        "resource_type": "HostNode",
        "windows_install_location": ""
      },
      "node_id": "4d758ec6-92ed-47a3-a9d6-eefd6242a3ea",
      "resource_type": "TransportNode",
      "tags": [
        {
          "scope": "policyPath",
          "tag": "/infra/sites/default/enforcement-points/default/host-transport-nodes/4d758ec6-92ed-47a3-a9d6-eefd6242a3ea"
        }
      ]
    }
  ],
  "sort_ascending": true,
  "sort_by": "create_time"
}
}
```